### PR TITLE
Require both CFLAGS and LDFLAGS to be empty in order to skip.

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -38,7 +38,7 @@ elsif ex = find_executable( "pkg-config" )
   ["lua", "lua5.1", "lua5.2"].any? do |l|
     ldf = `#{ex} --libs #{l}`.chomp
     cf = `#{ex} --cflags #{l}`.chomp
-    next false if ldf.empty? or cf.empty?
+    next false if ldf.empty? and cf.empty?
 
     $LDFLAGS << " #{ldf}"
     $CFLAGS  << " #{cf}"


### PR DESCRIPTION
In Fedora 20 I observed that installing ruby-lua-0.4.0 succeeded, but the compiled `lua.so` did not know to dynamically load the lua library. It was missing the `-llua` flag.

examining `extconf.rb` showed the when falling back to using `pkg-config` a result is skipped if both `cf` and `ldf` are empty. In Fedora 20 `CFLAGS` is empty, and that is not an error, while `LDFLAGS` has the missing libraries.

I thought the easiest change would be to make the `or` and `and` as you can see in the diff. If `pkg-config` has nothing to add to the compilation, try again. If it adds anything, assume it is correct and complete.
